### PR TITLE
Curl retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Makes forwarding to processing nodes more resiliant to network failures with the ability to retry forwarding a task by switching to another node in the network.