### PR TITLE
Vacuum offline ASR nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sometimes nodes go offline (due to memory errors or when in some cases the user cancels the tasks too rapidly). The ASR should vacuum those nodes.