### PR TITLE
Switch fix

### DIFF
--- a/libs/logger.js
+++ b/libs/logger.js
@@ -39,22 +39,19 @@ try {
 logPath += path.sep;
 logPath += package_info.name + ".log";
 
-let logger = new (winston.Logger)({
-  transports: [
-    new (winston.transports.Console)({ level: config.logger.level }),
-  ]
-});
-logger.add(winston.transports.File, {
-		filename: logPath, // Write to projectname.log
-		json: false, // Write in plain text, not JSON
-		maxsize: config.logger.maxFileSize, // Max size of each file
-		maxFiles: config.logger.maxFiles, // Max number of files
-		level: config.logger.level // Level of log messages
-	});
-
-if (config.deamon){
-	// Console transport is no use to us when running as a daemon
-	logger.remove(winston.transports.Console);
+let transports = [];
+if (!config.deamon){
+    transports.push(new winston.transports.Console({ level: config.logger.level, format: winston.format.simple() }));
 }
+
+let logger = winston.createLogger({ transports });
+logger.add(new winston.transports.File({
+        format: winston.format.simple(), 
+        filename: logPath, // Write to projectname.log
+        json: false, // Write in plain text, not JSON
+        maxsize: config.logger.maxFileSize, // Max size of each file
+        maxFiles: config.logger.maxFiles, // Max number of files
+        level: config.logger.level // Level of log messages
+    }));
 
 module.exports = logger;

--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -495,8 +495,14 @@ module.exports = {
                         // If autoscale is enabled, simply retry on same node
                         // otherwise switch to another node
                         if (!autoscale){
-                            node = await nodes.findBestAvailableNode(imagesCount, true);
-                            logger.warn(`Switched ${uuid} to ${node}`);
+                            const newNode = await nodes.findBestAvailableNode(imagesCount, true);
+                            if (newNode){
+                                node = newNode;
+                                logger.warn(`Switched ${uuid} to ${node}`);
+                            }else{
+                                // No nodes available
+                                logger.warn(`No other nodes available to process ${uuid}, we'll retry the same one.`);
+                            }
                         }
 
                         await doUpload();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "short-uuid": "^3.1.1",
     "tree-kill": "^1.2.1",
     "uuid": "^3.3.2",
-    "winston": "^2.2.0"
+    "winston": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a node goes offline, but no other nodes are available, a switch cannot happen during node selection.

Also upgrades Winston to remove warning messages.