### PR TITLE
Enforce upload limit counts before commit

### DIFF
--- a/libs/proxy.js
+++ b/libs/proxy.js
@@ -291,7 +291,25 @@ module.exports = {
                             cb => {
                                 taskNew.formDataParser(req, async function(params){
                                     if (!params.imagesCount) cb(new Error("No files uploaded."));
-                                    else cb();
+                                    else{
+                                        if (limits && limits.maxImages){
+                                            // Check if we've exceeding image limits
+                                            fs.readdir(saveFilesToDir, (err, files) => {
+                                                if (err){
+                                                    logger.warn(`Failed to read files from ${saveFilesToDir}`);
+                                                    cb();
+                                                }else if (files.length - 1 > limits.maxImages){
+                                                    // -1 accounts for _body.json
+                                                    cb(new Error("Max images count exceeded."));
+                                                }else{
+                                                    cb();
+                                                }
+                                            });
+                                        }else{
+                                            // No limits
+                                            cb();
+                                        }
+                                    }
                                 }, { saveFilesToDir, parseFields: false});
                             }
                         ], err => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Enforces upload limit checks before upload commit. Otherwise a user is theoretically allowed to upload infinite images regardless of the image limits.