### PR TITLE
Enforce maxImages limit on /task/new

### DIFF
--- a/libs/proxy.js
+++ b/libs/proxy.js
@@ -391,7 +391,7 @@ module.exports = {
                             die(e.message);
                             return;
                         }
-                    }, { saveFilesToDir: tmpPath });
+                    }, { saveFilesToDir: tmpPath, limits });
                 }else if (req.method === 'POST' && ['/task/restart', '/task/cancel', '/task/remove'].indexOf(pathname) !== -1){
                     // Lookup task id from body
                     let taskId = null;

--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -72,6 +72,7 @@ module.exports = {
     formDataParser: function(req, onFinish, options = {}){
         if (options.saveFilesToDir === undefined) options.saveFilesToDir = false;
         if (options.parseFields === undefined) options.parseFields = true;
+        if (options.limits === undefined) options.limits = {};
         
         const busboy = new Busboy({ headers: req.headers });
 
@@ -123,6 +124,12 @@ module.exports = {
         if (options.saveFilesToDir){
             busboy.on('file', async function(fieldname, file, filename, encoding, mimetype) {
                 if (fieldname === 'images'){
+                    if (options.limits.maxImages && params.imagesCount > options.limits.maxImages){
+                        params.error = "Max images count exceeded.";
+                        file.resume();
+                        return;
+                    }
+                    
                     filename = utils.sanitize(filename);
                     
                     // Special case

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As the title says. Limits were currently enforced only on /task/new/init.