### PR TITLE
Add spot fleet config file option

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -21,7 +21,7 @@ the on-demand instance cost - you'll always pay the current market price, not yo
 
 ## Using Spot Fleets
 
-Fleet configuation files allow you to increase the chance your spot request will be fulfilled in a timely manner. Refer to the AWS docs for a walkthrough on file generation (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html) & (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-examples.html). Add your spot fleet config path to 'spotFleetConfig'. Must set 'spot' to false.
+Fleet configuation files allow you to increase the chance your spot request will be fulfilled in a timely manner. Refer to the AWS docs for a walkthrough on file generation (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html) & (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-examples.html). Add your spot fleet config paths to 'spotFleetConfigMapping' for each image range (you may use the same file for multiple ranges). Must set 'spot' to false.
 
 ## Configuration File
 ```json

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -17,7 +17,11 @@ To optimise transfer speeds in large jobs, it's worth running ClusterODM in the 
 This provider supports requesting [EC2 spot instances](https://aws.amazon.com/ec2/spot/). Spot instances can save up to 90% of costs compared to
 normal on-demand instance costs which makes AWS very competitive with other cloud providers. Spot instances are reliable enough
 for long-running ODM jobs if the spot bid price is set high enough. It's common to request a bid price the same as
-the on-demand instance cost - you'll always pay the current market price, not your bid price.
+the on-demand instance cost - you'll always pay the current market price, not your bid price. Must set 'spotFleet' to false.
+
+## Using Spot Fleets
+
+Fleet configuation files allow you to increase the chance your spot request will be fulfilled in a timely manner. Refer to the AWS docs for a walkthrough on file generation (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html) & (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-examples.html). Add your spot fleet config path to 'spotFleetConfig'. Must set 'spot' to false.
 
 ## Configuration File
 ```json
@@ -42,6 +46,8 @@ the on-demand instance cost - you'll always pay the current market price, not yo
     "engineInstallUrl": "\"https://releases.rancher.com/install-docker/19.03.9.sh\"",
     
     "spot": true,
+    "spotFleet": false,
+    "spotFleetConfig": "path/to/config.json",
     "imageSizeMapping": [
         {"maxImages": 40, "slug": "t3a.small", "spotPrice": 0.02, "storage": 60},
         {"maxImages": 80, "slug": "t3a.medium", "spotPrice": 0.04, "storage": 100},
@@ -64,14 +70,16 @@ the on-demand instance cost - you'll always pay the current market price, not yo
 | secretKey        | AWS Secret Key                                                                                                                                             |
 | s3               | S3 bucket configuration. Note that the bucket should *not* be configured to block public access.                                                           |
 | securityGroup    | AWS Security Group name (not ID). Must exist and allow incoming connections from your ClusterODM host on port TCP/3000.                                    |
-| createRetries    | Number of attempts to create a droplet before giving up. Defaults to 1.
+| createRetries    | Number of attempts to create a droplet before giving up. Defaults to 1.                                                                                    |
 | maxRuntime       | Maximum number of seconds an instance is allowed to run ever. Set to -1 for no limit.                                                                      |
 | maxUploadTime    | Maximum number of seconds an instance is allowed to receive file uploads. Set to -1 for no limit.                                                          |
 | monitoring       | Set to true to enable detailed Cloudwatch monitoring for the instance.                                                                                     |
 | region           | Region identifier where the instances should be created.                                                                                                   |
 | ami              | The AMI (machine image) to launch this instance from.                                                                                                      |
-| tags             | Comma-separated list of key,value tags to associate to the instance.                                                                                      |
-| spot             | Whether to request spot instances. If this is true, a `spotPrice` needs to be provided in the `imageSizeMapping`.                                          |
+| tags             | Comma-separated list of key,value tags to associate to the instance.                                                                                       |
+| spot             | Whether to request spot instances. If this is true, a `spotPrice` needs to be provided in the `imageSizeMapping` and `spotFleet` must be set to false.     |
+| spotFleet        | Whether to use a spot fleet config file. If this is true, add your spot fleet config path to `spotFleetConfig` and `spotFleet` must be set to false.       |
+| spotFleetConfig  | Path to spot fleet config File.                                                                                                                            |
 | imageSizeMapping | Max images count to instance size mapping. (See below.)                                                                                                    |
 | addSwap          | Optionally add this much swap space to the instance as a factor of total RAM (`RAM * addSwap`). A value of `1` sets a swapfile equal to the available RAM. |
 | dockerImage      | Docker image to launch                                                                                                                                     |

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -46,8 +46,6 @@ Fleet configuation files allow you to increase the chance your spot request will
     "engineInstallUrl": "\"https://releases.rancher.com/install-docker/19.03.9.sh\"",
     
     "spot": true,
-    "spotFleet": false,
-    "spotFleetConfig": "path/to/config.json",
     "imageSizeMapping": [
         {"maxImages": 40, "slug": "t3a.small", "spotPrice": 0.02, "storage": 60},
         {"maxImages": 80, "slug": "t3a.medium", "spotPrice": 0.04, "storage": 100},
@@ -57,6 +55,18 @@ Fleet configuation files allow you to increase the chance your spot request will
 		{"maxImages": 2500, "slug": "r5.2xlarge", "spotPrice": 0.6, "storage": 1200},
 		{"maxImages": 3500, "slug": "r5.4xlarge", "spotPrice": 1.1, "storage": 2000},
 		{"maxImages": 5000, "slug": "r5.4xlarge", "spotPrice": 1.1, "storage": 2500}
+    ],
+
+    "spotFleet": false,
+    "spotFleetConfigMapping": [
+        {"maxImages": 40, "spotFleetConfigFile": "./path/to/config40.json"},
+        {"maxImages": 80, "spotFleetConfigFile": "./path/to/config80.json"},
+        {"maxImages": 250, "spotFleetConfigFile": "./path/to/config250.json"},
+        {"maxImages": 500, "spotFleetConfigFile": "./path/to/config500.json"},
+        {"maxImages": 1500, "spotFleetConfigFile": "./path/to/config1500.json"},
+        {"maxImages": 2500, "spotFleetConfigFile": "./path/to/config2500.json"},
+        {"maxImages": 3500, "spotFleetConfigFile": "./path/to/config3500.json"},
+        {"maxImages": 5000, "spotFleetConfigFile": "./path/to/config5000.json"}
     ],
 
     "addSwap": 1,
@@ -79,7 +89,7 @@ Fleet configuation files allow you to increase the chance your spot request will
 | tags             | Comma-separated list of key,value tags to associate to the instance.                                                                                       |
 | spot             | Whether to request spot instances. If this is true, a `spotPrice` needs to be provided in the `imageSizeMapping` and `spotFleet` must be set to false.     |
 | spotFleet        | Whether to use a spot fleet config file. If this is true, add your spot fleet config path to `spotFleetConfig` and `spotFleet` must be set to false.       |
-| spotFleetConfig  | Path to spot fleet config File.                                                                                                                            |
+| spotFleetConfigMapping  | Paths to spot fleet config file for each image range.                                                                                               |
 | imageSizeMapping | Max images count to instance size mapping. (See below.)                                                                                                    |
 | addSwap          | Optionally add this much swap space to the instance as a factor of total RAM (`RAM * addSwap`). A value of `1` sets a swapfile equal to the available RAM. |
 | dockerImage      | Docker image to launch                                                                                                                                     |

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -88,7 +88,7 @@ Fleet configuation files allow you to increase the chance your spot request will
 | ami              | The AMI (machine image) to launch this instance from.                                                                                                      |
 | tags             | Comma-separated list of key,value tags to associate to the instance.                                                                                       |
 | spot             | Whether to request spot instances. If this is true, a `spotPrice` needs to be provided in the `imageSizeMapping` and `spotFleet` must be set to false.     |
-| spotFleet        | Whether to use a spot fleet config file. If this is true, add your spot fleet config path to `spotFleetConfig` and `spotFleet` must be set to false.       |
+| spotFleet        | Whether to use a spot fleet config file. If this is true, add your spot fleet config path to `spotFleetConfig` and `spot` must be set to false.            |
 | spotFleetConfigMapping  | Paths to spot fleet config file for each image range.                                                                                               |
 | imageSizeMapping | Max images count to instance size mapping. (See below.)                                                                                                    |
 | addSwap          | Optionally add this much swap space to the instance as a factor of total RAM (`RAM * addSwap`). A value of `1` sets a swapfile equal to the available RAM. |

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -168,7 +168,7 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             "--amazonec2-secret-key", this.getConfig("secretKey")
         ];
 
-        if (this.getConfig("spotFleet")) {
+        if (!this.getConfig("spotFleet")) {
             args.push("--amazonec2-region", this.getConfig("region"));
             args.push("--amazonec2-ami", this.getConfig("ami"));
             args.push("--amazonec2-instance-type", image_props["slug"]);

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -128,7 +128,13 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
     }
 
     getImagePropertiesFor(imagesCount){
+        
         const im = this.getConfig("imageSizeMapping");
+        
+        if (this.getConfig("spotFleet")){
+            im = this.getConfig("spotFleetConfigMapping");
+        }
+        
 
         let props = null;
         for (var k in im){
@@ -177,10 +183,10 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
         if (this.getConfig("spotFleet", false)) {
             // Validate spotFleetConfig path
-            const spotFleetConfigPath = this.getConfig("spotFleetConfig", "");
+            const spotFleetConfigPath = image_props["spotFleetConfigFile"];
             if (spotFleetConfigPath){
                 logger.info("Using Spot Fleet Config File");
-                const exists = await new Promise((resolve) => fs.exists(this.getConfig("spotFleetConfig"), resolve));
+                const exists = await new Promise((resolve) => fs.exists(spotFleetConfigPath, resolve));
             if (!exists) throw new Error("Invalid Spot File Config spotFleetConfig: file does not exist");
             }
             else {

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -192,11 +192,13 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             if (spotFleetConfigPath){
                 logger.info("Using Spot Fleet Config File");
                 const exists = await new Promise((resolve) => fs.exists(spotFleetConfigPath, resolve));
-            if (!exists) throw new Error("Invalid Spot File Config spotFleetConfig: file does not exist");
-            }
-            else {
-                args.push("--spot-fleet-request-config");
-                args.push(spotFleetConfigPath);
+                if (!exists) {
+                   throw new Error("Invalid Spot File Config spotFleetConfig: file does not exist");
+                   logger.info(spotFleetConfigPath + " does not exist");
+                }
+                else {
+                    args.push("--spot-fleet-request-config file://" + spotFleetConfigPath);
+                }
             }
         }
 

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -129,9 +129,12 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
     getImagePropertiesFor(imagesCount){
         
-        const im = this.getConfig("imageSizeMapping");
-        
-        if (this.getConfig("spotFleet")){
+        var im = [];
+
+        if (!this.getConfig("spotFleet")){
+            im = this.getConfig("imageSizeMapping");
+        }
+        else {
             im = this.getConfig("spotFleetConfigMapping");
         }
         

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -168,7 +168,7 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             "--amazonec2-secret-key", this.getConfig("secretKey")
         ];
 
-        if (this.getConfig("spotFleet"), false) {
+        if (this.getConfig("spotFleet")) {
             args.push("--amazonec2-region", this.getConfig("region"));
             args.push("--amazonec2-ami", this.getConfig("ami"));
             args.push("--amazonec2-instance-type", image_props["slug"]);
@@ -176,17 +176,17 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             args.push("--amazonec2-security-group", this.getConfig("securityGroup"));
         }
 
-        if (this.getConfig("monitoring", false)) {
+        if (this.getConfig("monitoring")) {
             args.push("--amazonec2-monitoring");
         }
 
-        if (this.getConfig("spot", false)) {
+        if (this.getConfig("spot")) {
             args.push("--amazonec2-request-spot-instance");
             args.push("--amazonec2-spot-price");
             args.push(image_props["spotPrice"]);
         }
 
-        if (this.getConfig("spotFleet", false)) {
+        if (this.getConfig("spotFleet")) {
             // Validate spotFleetConfig path
             const spotFleetConfigPath = image_props["spotFleetConfigFile"];
             if (spotFleetConfigPath){

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -46,6 +46,8 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
                 {"maxImages": 50, "slug": "t2.medium", "spotPrice": 0.1, "storage": 100}
             ],
 
+            "spotFleet": false,
+
             "addSwap": 1,
             "dockerImage": "opendronemap/nodeodm"
         }, userConfig);


### PR DESCRIPTION
AWS spot fleet config files are a rabbit hole for sure. API docs are usually fun but this stuff gets intense. Changes keep existing functionality intact but adds the option for independent fleet config files for different image ranges. 