### PR TITLE
Add support for detecting stale uploads 

### DIFF
--- a/config-default.json
+++ b/config-default.json
@@ -13,6 +13,7 @@
     "log-level": "info",
     "upload-max-speed": 0,
     "flood-limit": 0,
+    "stale-uploads-timeout": 0,
     "ssl-key": "",
     "ssl-cert": "",
     "asr-provider": "",

--- a/config.js
+++ b/config.js
@@ -45,7 +45,7 @@ let argDefs = {
     default: defaultConfig,
 
     int: ['port', 'admin-cli-port', 'admin-web-port', 
-          'secure-port', 'upload-max-speed', 'flood-limit'] // for cast only, not used by minimist
+          'secure-port', 'upload-max-speed', 'flood-limit', 'stale-uploads-timeout'] // for cast only, not used by minimist
 };
 let argv = require('minimist')(process.argv.slice(2), argDefs);
 
@@ -67,6 +67,7 @@ Options:
     --no-splitmerge	By default the program will set itself as being a cluster node for all split/merge tasks. Setting this option disables it. (default: false)
     --public-address <http(s)://host:port>	Should be set to a public URL that nodes can use to reach ClusterODM. (default: match the "host" header from client's HTTP request)
     --flood-limit <number>	Limit the number of simultaneous task uploads that a user can initiate concurrently (default: no limit)
+    --stale-uploads-timeout <number>	Delete temporary uploads if no activity is recorded for these many hours. After 48 hours stale uploads are always removed regardless of this option. (default: do not remove stale uploads)
     --token <token> Sets a token that needs to be passed for every request. This can be used to limit access to the node only to token holders. (default: none)
     --debug 	Disable caches and other settings to facilitate debug (default: false)
     --ssl-key <file>	Path to .pem SSL key file

--- a/libs/proxy.js
+++ b/libs/proxy.js
@@ -39,13 +39,13 @@ const floodMonitor = require('./floodMonitor');
 
 module.exports = {
 	initialize: async function(cloudProvider){
-        utils.cleanupTemporaryDirectory();
+        utils.cleanupTemporaryDirectory(config.stale_uploads_timeout);
         await routetable.initialize();
         await tasktable.initialize();
 
         setInterval(() => {
-            utils.cleanupTemporaryDirectory();
-        }, 1000 * 60 * 60 * 4);
+            utils.cleanupTemporaryDirectory(config.stale_uploads_timeout);
+        }, 1000 * 60 * 30);
 
         // Allow index, .css and .js files to be retrieved from nodes
         // without authentication
@@ -309,7 +309,7 @@ module.exports = {
                         async.series([
                             cb => {
                                 fs.exists(saveFilesToDir, exists => {
-                                    if (!exists) cb(new Error("Invalid taskId (dir not found)"));
+                                    if (!exists) cb(new Error("Invalid taskId: the task no longer exists."));
                                     else cb();
                                 });
                             },
@@ -361,6 +361,7 @@ module.exports = {
                         }
 
                         floodMonitor.recordTaskCommit(query.token);
+                        utils.markTaskAsCommitted(taskId);
 
                         async.series([
                             cb => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 - [x] Allows to set options such as `--stale-uploads-timeout 1` which will detect when a task upload has stalled for longer than 1 hour (no activity is recorded for more than 1 hour) and cleanup disk space.