### PR TITLE
Handle socket timeouts during /task/new/upload

### DIFF
--- a/libs/proxy.js
+++ b/libs/proxy.js
@@ -303,6 +303,11 @@ module.exports = {
                         });
                     });
                 }else if (req.method === 'POST' && pathname.indexOf('/task/new/upload') === 0){
+                    // Destroy sockets after 30s of inactivity
+                    req.setTimeout(30000, () => {
+                        req.destroy();
+                    });
+
                     const taskId = taskNew.getTaskIdFromPath(pathname);
                     if (taskId){
                         const saveFilesToDir = path.join('tmp', taskId);

--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -172,11 +172,18 @@ module.exports = {
                             saveStream.close();
                             saveStream = null;
                         }
+                        if (fs.exists(saveTo, exists => {
+                            fs.unlink(saveTo, err => {
+                                if (err) logger.error(err);
+                            });
+                        }));
                     };
                     req.on('close', handleClose);
+                    req.on('abort', handleClose);
 
                     file.on('end', () => {
                         req.removeListener('close', handleClose);
+                        req.removeListener('abort', handleClose);
                         saveStream = null;
                     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a user drops the connection, files are left in the temporary upload directory, potentially distorting the max images count limits as well as potentially forwarding corrupted data to NodeODM nodes.