### PR TITLE
docker-machine: brings the docker image up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ EXPOSE 3000
 USER root
 
 RUN apt update && apt install -y telnet curl && \
-    base=https://github.com/docker/machine/releases/download/v0.16.0 && \
+    base=https://gitlab-docker-machine-downloads.s3.amazonaws.com/main/ && \
     curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine && \
-    install /tmp/docker-machine /usr/local/bin/docker-machine
+    install /tmp/docker-machine /usr/local/bin/docker-machine && \
+    curl -L https://github.com/scaleway/docker-machine-driver-scaleway/releases/download/v1.6/docker-machine-driver-scaleway_1.6_linux_amd64.tar.gz | tar -xz --directory=/tmp && \
+    install --mode +x /tmp/docker-machine-driver-scaleway /usr/local/bin/ && \
+    curl -L https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/2.0.1/docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz | tar -xz --directory=/tmp && \
+    install --mode +x /tmp/docker-machine-driver-hetzner /usr/local/bin/
 
 COPY . /var/www
 WORKDIR "/var/www"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See `node index.js --help` for all parameter options.
 ClusterODM can spin up/down nodes based on demand. This allows users to reduce costs associated with always-on instances as well as being able to scale processing based on demand.
 
 To setup autoscaling you must:
-   * Make sure [docker-machine](https://docs.docker.com/machine/install-machine/) is installed.
+   * Make sure [docker-machine](https://gitlab.com/gitlab-org/ci-cd/docker-machine) is installed.
    * Setup a S3-compatible bucket for storing results.
    * Create a configuration file for [DigitalOcean](./docs/digitalocean.md), [Hetzner](./docs/hetzner.md), [Scaleway](./docs/scaleway.md), or [Amazon Web Services](./docs/aws.md) (click links to see examples)
 
@@ -99,4 +99,3 @@ clusterodm.exe
 ## Roadmap
 
 We have [plenty of goals](https://github.com/OpenDroneMap/ClusterODM/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). If you want to help, or need help getting started contributing, get in touch on the [OpenDroneMap community forum](https://community.opendronemap.org).
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - "10000:10000"
     volumes:
       - ./docker/data:/var/www/data
+      - ./configuration.json:/var/www/
     restart: on-failure:10
+    command: --asr /var/www/configuration.json
     depends_on:
       - nodeodm-1

--- a/docs/hetzner.md
+++ b/docs/hetzner.md
@@ -3,15 +3,14 @@
 Hetzner is an unofficial driver for docker-machine. This means you need to install the driver for hetzner separately before you can use it.
 
 1. Download the latest version of the driver from https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases
-2. Extract the binary and place it in your PATH. 
+2. Extract the binary and place it in your PATH.
 
 For example on Linux you can do:
 
 ```bash
-wget wget https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/2.0.1/docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz
+wget https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/2.0.1/docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz
 tar -xvf docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz
-chmod +x docker-machine-driver-hetzner
-sudo mv docker-machine-driver-hetzner /usr/local/bin
+sudo install --mode +x docker-machine-driver-hetzner /usr/local/bin/
 ```
 
 # Provider Configuration for Hetzner
@@ -34,11 +33,11 @@ Example configuration file:
     "machinesLimit": -1,
     "createRetries": 1,
     "location": "fsn1",
-    
+
     "image": "ubuntu-18.04",
     "snapshot": false,
     "engineInstallUrl": "\"https://releases.rancher.com/install-docker/19.03.9.sh\"",
-    
+
     "sshKey":{
         "fingerprint": "",
         "path": "",

--- a/docs/scaleway.md
+++ b/docs/scaleway.md
@@ -3,15 +3,14 @@
 Scaleway is an unofficial driver for docker-machine. This means you need to install the driver for scaleway separately before you can use it.
 
 1. Download the latest version of the driver from https://github.com/scaleway/docker-machine-driver-scaleway/releases
-2. Extract the binary and place it in your PATH. 
+2. Extract the binary and place it in your PATH.
 
 For example on Linux you can do:
 
 ```bash
 wget https://github.com/scaleway/docker-machine-driver-scaleway/releases/download/v1.6/docker-machine-driver-scaleway_1.6_linux_amd64.tar.gz
 tar -xvf docker-machine-driver-scaleway_1.6_linux_amd64.tar.gz
-chmod +x docker-machine-driver-scaleway
-sudo mv docker-machine-driver-scaleway /usr/local/bin
+sudo install --mode +x docker-machine-driver-scaleway /usr/local/bin
 ```
 
 # Provider Configuration for Scaleway
@@ -36,10 +35,10 @@ Example configuration file:
     "machinesLimit": -1,
     "createRetries": 1,
     "region": "par1",
-    
+
     "image": "ubuntu-xenial",
     "engineInstallUrl": "\"https://releases.rancher.com/install-docker/19.03.9.sh\"",
-    
+
     "imageSizeMapping": [
         {"maxImages": 5, "slug": "GP1-XS"},
         {"maxImages": 50, "slug": "GP1-S"}
@@ -66,4 +65,3 @@ Example configuration file:
 | minImages                | Minimum number of images that a dataset needs to have for the autoscaler to be used (-1 = no minimum).                                                                                                                                                                                                              |
 | addSwap                  | Optionally add this much swap space to the machine as a factor of total RAM (`RAM * addSwap`). A value of `1` sets a swapfile equal to the available RAM.                                                                                                                                                         |
 | dockerImage              | Docker image to launch                                                                                                                                                                                                                                                                                            |
-


### PR DESCRIPTION
This PR fixes a lot of different things, all related to the deprecation of docker-machine.

First of, as docker-machine is being deprecated by Docker, maintenance has been taken over by Gitlab.
The first commit bring several changes:
- Update the documentation to reflect the new home of docker-machine
- Update the Dockerfile to change docker-machine URI to the gitlab build
- Update the Dockerfile to include by default the Scaleway and Hertzner drivers
- Update the documentation of Scaleway and Hertzner to reflect changes made in Dockerfile

The second commit is more of a usability point of view regarding the docker-compose.yml. There was previously no way to specify a `configuration.json` file to start docker compose with a autoscale configuration (even if in the documentation, the ability to use docker-compose is mentioned in the Autoscale section. This is now fixed.