### PR TITLE
fix NodeJS version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:14
 MAINTAINER Piero Toffanin <pt@masseranolabs.com>
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The program has been battle tested on the [WebODM Lightning Network](https://web
 
 ## Installation
 
-The only requirement is a working installation of [NodeJS](https://nodejs.org).
+The only requirement is a working installation of [NodeJS](https://nodejs.org) 14 or earlier (ClusterODM has compatibility issues with NodeJS 16 and later).
 
 ```bash
 git clone https://github.com/OpenDroneMap/ClusterODM


### PR DESCRIPTION
ClusterODM is not working with NodeJS 16 (current LTS), so NodeJS version was changed from `lts `to `14` in the Dockerfile.

Compatibility information has been added to the README

resolves #92 