### PR TITLE
Update Apptainer documentation for ClusterODM

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Or with docker:
 docker run --rm -ti -p 3000:3000 -p 8080:8080 opendronemap/clusterodm [parameters]
 ```
 
+Or with apptainer:
+
+```bash
+apptainer run docker://opendronemap/clusterodm [parameters]
+```
+
 Then connect to the CLI and connect new [NodeODM](https://github.com/OpenDroneMap/NodeODM) instances:
 
 ```bash


### PR DESCRIPTION
Even though most of the problems circulating using ODM on HPC is solved by using apptainer to build and run NodeODM. The user can also use apptainer to run the Docker container for ClusterODM if prefer. Here we're updating the documentation.