### PR TITLE
Added kubernetes deployment file and associated README.md

### DIFF
--- a/Contrib/kubernetes/README.md
+++ b/Contrib/kubernetes/README.md
@@ -2,7 +2,7 @@
 The following provides a means to run ClusterODM on your master node and a series of NodeODM instances on worker nodes in a kubernetes cluster.
 The configuration uses GPU's if they are setup on your kubernetes cluster.
 
-## Preparatioe
+## Preparation
 Before deploying it is important to make the following changes In the file k8clusternodeodm.yml
 
 change EXTERNALIPADDRESS to the external ip adddress of your k8 cluster

--- a/Contrib/kubernetes/README.md
+++ b/Contrib/kubernetes/README.md
@@ -1,0 +1,40 @@
+# Kubernetes Deployment
+The following provides a means to run ClusterODM on your master node and a series of NodeODM instances on worker nodes in a kubernetes cluster.
+The configuration uses GPU's if they are setup on your kubernetes cluster.
+
+## Preparatioe
+Before deploying it is important to make the following changes In the file k8clusternodeodm.yml
+
+change EXTERNALIPADDRESS to the external ip adddress of your k8 cluster
+change the number of replicas (REPNUM) for nodeodm to the number of nodes in your cluster (I suggest 1 nodeodm per cluster node)
+
+## Deploy into the k8 cluster
+On the  master/head node run the command:
+
+kubectl apply -f k8clusternodeodm.yml
+
+This will then start up 2 deployments
+- Deployment 1 with ClusterODM
+- Deployment 2 with N replicas of NodeODM.
+
+## Post Deployment Configuration
+Once the pods are running you should be able to connect to ClusterODM on http://EXTERNALIPADDRESS:10000 and then add the NodeODM nodes.
+
+### Adding NodeODM nodes to ClusterODM
+On the master/head node issue the command: 
+
+kubectl get pods -o wide 
+
+This will supply you with the IP Address details that you need to enter into the ClsuterODM configuration page or add via telnet session.
+
+The following shows the type of output you should get and the IP address details
+NAME                                                       READY   STATUS    RESTARTS      AGE     IP              NODE          NOMINATED NODE   READINESS GATES
+nodeodm-deployment-6d454b88d5-2z5rh                        1/1     Running   0             157m    172.29.8.86     gigganode02   <none>           <none>
+nodeodm-deployment-6d454b88d5-5cksx                        1/1     Running   0             148m    172.29.26.145   gigganode03   <none>           <none>
+nodeodm-deployment-6d454b88d5-78wd2                        1/1     Running   0             157m    172.29.6.183    gigganode01   <none>           <none>
+nodeodm-deployment-6d454b88d5-7m8pm                        1/1     Running   0             148m    172.29.26.130   gigganode03   <none>           <none>
+nodeodm-deployment-6d454b88d5-bfgps                        1/1     Running   0             148m    172.29.26.153   gigganode03   <none>           <none>
+
+### WebODM Configuration
+Add the ClusterODM as a Processing Node using the details
+EXTERNALIPADDRESS:3000

--- a/Contrib/kubernetes/k8clusternodeodm.yml
+++ b/Contrib/kubernetes/k8clusternodeodm.yml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodeodm-deployment
+spec:
+  replicas: REPNUM 
+  selector:
+    matchLabels:
+      app: nodeodm
+  template:
+    metadata:
+      labels:
+        app: nodeodm
+    spec:
+      containers:
+        - name: nodeodm
+          image: opendronemap/nodeodm:gpu
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: data-volume
+              mountPath: /cm/local
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clusterodm-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clusterodm
+  template:
+    metadata:
+      labels:
+        app: clusterodm
+    spec:
+      containers:
+        - name: clusterodm
+          image: opendronemap/clusterodm
+          ports:
+            - containerPort: 3000
+            - containerPort: 10000
+            - containerPort: 8080
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodeodm-service
+spec:
+  type: NodePort
+  selector:
+    app: nodeodm
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+      nodePort: 30000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusterodm-service
+spec:
+  type: LoadBalancer
+  externalIPs:
+    - EXTERNALIPADDRESS
+  ports:
+    - name: port-3000
+      port: 3000
+      targetPort: 3000
+    - name: port-10000
+      port: 10000
+      targetPort: 10000
+    - name: port-8080
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: clusterodm


### PR DESCRIPTION
I have created a Contrib folder and then added a kubernetes section under that. 
There are two new files

k8clusternodeodm.yml   - sets up ClusterODM and NodeODM as two deployments on a k8 cluster
README.md - explains what needs to be done to start

This configuration has been tested with a production k8 cluster managed by NVIDIA Bright Cluster Manager.