### PR TITLE
Support for 'maxColSizeMb' autoscaling config parameter

### DIFF
--- a/admincli.js
+++ b/admincli.js
@@ -232,8 +232,8 @@ module.exports = {
                         const subcommand = args[0].toLocaleUpperCase();
                         args = args.slice(1, args.length);
                         if (subcommand === "VIEWCMD"){
-                            const [ numImages ] = args;
-                            const cmd = await asr.debugCreateDockerMachineCmd(numImages);
+                            const [ numImages, colSizeMb ] = args;
+                            const cmd = await asr.debugCreateDockerMachineCmd(numImages, colSizeMb);
                             socket.write(`${cmd}\r\n`);
                         }else{
                             invalid();

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -95,9 +95,10 @@ instance able to process the requested number of images is always selected.
 
 [EC2Instances.info](https://www.ec2instances.info) is a useful resource to help in selecting the appropriate instance type.
 
-| Field     | Description                                                                                       |
-|-----------|---------------------------------------------------------------------------------------------------|
-| maxImages | The maximum number of images this instance size can handle.                                       |
-| slug      | EC2 instance type to request (for example, `t3.medium`).                                          |
-| storage   | Amount of storage to allocate to this instance's EBS root volume, in GB.                          |
-| spotPrice | The maximum hourly price you're willing to bid for this instance (if spot instances are enabled). |
+| Field        | Description                                                                                       |
+|--------------|---------------------------------------------------------------------------------------------------|
+| maxImages    | The maximum number of images this instance size can handle.                                       |
+| maxColSizeMb | Optional. The maximum size of an image collection this instance size can handle.                  |
+| slug         | EC2 instance type to request (for example, `t3.medium`).                                          |
+| storage      | Amount of storage to allocate to this instance's EBS root volume, in GB.                          |
+| spotPrice    | The maximum hourly price you're willing to bid for this instance (if spot instances are enabled). |

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -99,8 +99,8 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
         return `https://${this.getConfig("s3.bucket")}.${this.getConfig("s3.endpoint")}`;
     }
 
-    canHandle(imagesCount){
-        return this.getImagePropertiesFor(imagesCount) !== null;
+    canHandle(imagesCount, colSizeMb){
+        return this.getImagePropertiesFor(imagesCount, colSizeMb) !== null;
     }
 
     async setupMachine(req, token, dm, nodeToken){
@@ -138,13 +138,13 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
                      `--token ${nodeToken}`].join(" "));
     }
 
-    getImagePropertiesFor(imagesCount){
+    getImagePropertiesFor(imagesCount, colSizeMb){
         const im = this.getConfig("imageSizeMapping");
 
         let props = null;
         for (var k in im){
             const mapping = im[k];
-            if (mapping['maxImages'] >= imagesCount){
+            if (mapping['maxImages'] >= imagesCount && (mapping['maxColSizeMb'] == null || mapping['maxColSizeMb'] >= colSizeMb)){
                 props = mapping;
                 break;
             }
@@ -161,8 +161,8 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
-        const image_props = this.getImagePropertiesFor(imagesCount);
+    async getCreateArgs(imagesCount, colSizeMb){
+        const image_props = this.getImagePropertiesFor(imagesCount, colSizeMb);
         const args = [
             "--amazonec2-access-key", this.getConfig("accessKey"),
             "--amazonec2-secret-key", this.getConfig("secretKey"),

--- a/libs/asr-providers/digitalocean.js
+++ b/libs/asr-providers/digitalocean.js
@@ -103,10 +103,10 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
         return `https://${this.getConfig("s3.bucket")}.${this.getConfig("s3.endpoint")}`;
     }
 
-    canHandle(imagesCount){
+    canHandle(imagesCount, colSizeMb){
         const minImages = this.getConfig("minImages", -1);
 
-        return this.getImageSlugFor(imagesCount) !== null && 
+        return this.getImageSlugFor(imagesCount, colSizeMb) !== null && 
                (minImages === -1 || imagesCount >= minImages);
     }
 
@@ -137,13 +137,13 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
                      `--token ${nodeToken}`].join(" "));
     }
 
-    getImageSlugFor(imagesCount){
+    getImageSlugFor(imagesCount, colSizeMb){
         const im = this.getConfig("imageSizeMapping");
 
         let slug = null;
         for (var k in im){
             const mapping = im[k];
-            if (mapping['maxImages'] >= imagesCount){
+            if (mapping['maxImages'] >= imagesCount && (mapping['maxColSizeMb'] == null || mapping['maxColSizeMb'] >= colSizeMb)){
                 slug = mapping['slug'];
                 break;
             }
@@ -204,14 +204,14 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
         };
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, colSizeMb){
         const imageInfo = await this.getImageInfo();
 
         const args = [
             "--digitalocean-access-token", this.getConfig("accessToken"),
             "--digitalocean-region", imageInfo.region,
             "--digitalocean-image", imageInfo.image,
-            "--digitalocean-size", this.getImageSlugFor(imagesCount)
+            "--digitalocean-size", this.getImageSlugFor(imagesCount, colSizeMb)
         ];
 
         if (this.getConfig("monitoring")){

--- a/libs/asr-providers/hetzner.js
+++ b/libs/asr-providers/hetzner.js
@@ -103,10 +103,10 @@ module.exports = class HetznerAsrProvider extends AbstractASRProvider{
         return `https://${this.getConfig("s3.bucket")}.${this.getConfig("s3.endpoint")}`;
     }
 
-    canHandle(imagesCount){
+    canHandle(imagesCount, colSizeMb){
         const minImages = this.getConfig("minImages", -1);
 
-        return this.getImageSlugFor(imagesCount) !== null && 
+        return this.getImageSlugFor(imagesCount, colSizeMb) !== null && 
                (minImages === -1 || imagesCount >= minImages);
     }
 
@@ -188,13 +188,13 @@ module.exports = class HetznerAsrProvider extends AbstractASRProvider{
                      `--token ${nodeToken}`].join(" "));
     }
 
-    getImageSlugFor(imagesCount){
+    getImageSlugFor(imagesCount, colSizeMb){
         const im = this.getConfig("imageSizeMapping");
 
         let slug = null;
         for (var k in im){
             const mapping = im[k];
-            if (mapping['maxImages'] >= imagesCount){
+            if (mapping['maxImages'] >= imagesCount && (mapping['maxColSizeMb'] == null || mapping['maxColSizeMb'] >= colSizeMb)){
                 slug = mapping['slug'];
                 break;
             }
@@ -211,11 +211,11 @@ module.exports = class HetznerAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, colSizeMb){
         const args = [
             "--hetzner-api-token", this.getConfig("apiToken"),
             "--hetzner-server-location", this.getConfig("location"),
-            "--hetzner-server-type", this.getImageSlugFor(imagesCount)
+            "--hetzner-server-type", this.getImageSlugFor(imagesCount, colSizeMb)
         ];
 
         if (this.getConfig("snapshot")){

--- a/libs/asr-providers/scaleway.js
+++ b/libs/asr-providers/scaleway.js
@@ -86,10 +86,10 @@ module.exports = class ScalewayAsrProvider extends AbstractASRProvider{
         return `https://${this.getConfig("s3.bucket")}.${this.getConfig("s3.endpoint")}`;
     }
 
-    canHandle(imagesCount){
+    canHandle(imagesCount, colSizeMb){
         const minImages = this.getConfig("minImages", -1);
 
-        return this.getImageSlugFor(imagesCount) !== null && 
+        return this.getImageSlugFor(imagesCount, colSizeMb) !== null && 
                (minImages === -1 || imagesCount >= minImages);
     }
 
@@ -120,13 +120,13 @@ module.exports = class ScalewayAsrProvider extends AbstractASRProvider{
                      `--token ${nodeToken}`].join(" "));
     }
 
-    getImageSlugFor(imagesCount){
+    getImageSlugFor(imagesCount, colSizeMb){
         const im = this.getConfig("imageSizeMapping");
 
         let slug = null;
         for (var k in im){
             const mapping = im[k];
-            if (mapping['maxImages'] >= imagesCount){
+            if (mapping['maxImages'] >= imagesCount && (mapping['maxColSizeMb'] == null || mapping['maxColSizeMb'] >= colSizeMb)){
                 slug = mapping['slug'];
                 break;
             }
@@ -143,13 +143,13 @@ module.exports = class ScalewayAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, colSizeMb){
         const args = [
             "--scaleway-organization", this.getConfig("organization"),
             "--scaleway-token", this.getConfig("secretToken"),
             "--scaleway-region", this.getConfig("region"),
             "--scaleway-image", this.getConfig("image"),
-            "--scaleway-commercial-type", this.getImageSlugFor(imagesCount)
+            "--scaleway-commercial-type", this.getImageSlugFor(imagesCount, colSizeMb)
         ];
 
         if (this.getConfig("engineInstallUrl")){

--- a/libs/asrProvider.js
+++ b/libs/asrProvider.js
@@ -64,9 +64,9 @@ module.exports = {
         return (asrProvider.getNodesPendingCreation() + autoSpawnedNodesCount) < asrProvider.getMachinesLimit();
     },
 
-    canHandle: function(imagesCount){
+    canHandle: function(imagesCount, colSizeMb){
         if (!asrProvider) return false;
-        return asrProvider.canHandle(imagesCount);
+        return asrProvider.canHandle(imagesCount, colSizeMb);
     },
 
     onCommit: async function(taskId, cleanupDelay = 0){

--- a/libs/classes/AbstractASRProvider.js
+++ b/libs/classes/AbstractASRProvider.js
@@ -46,11 +46,11 @@ module.exports = class AbstractASRProvider{
         throw new Error("Not implemented");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, colSizeMb){
         throw new Error("Not implemented");
     }
 
-    canHandle(imagesCount){
+    canHandle(imagesCount, colSizeMb){
         throw new Error("Not implemented");
     }
 
@@ -98,8 +98,8 @@ module.exports = class AbstractASRProvider{
     }
 
     // Helper function for debugging
-    async debugCreateDockerMachineCmd(imagesCount){
-        const args = await this.getCreateArgs(imagesCount);
+    async debugCreateDockerMachineCmd(imagesCount, colSizeMb){
+        const args = await this.getCreateArgs(imagesCount, colSizeMb);
         return `docker-machine create --driver ${this.getDriverName()} ${args.join(" ")} debug-machine`;
     }
 
@@ -110,12 +110,12 @@ module.exports = class AbstractASRProvider{
     // @param hostname {String} docker-machine hostname
     // @param status {Object} status information about the task being created
     // @return {Node} a new Node instance
-    async createNode(req, imagesCount, token, hostname, status){
-        if (!this.canHandle(imagesCount)) throw new Error(`Cannot handle ${imagesCount} images.`);
+    async createNode(req, imagesCount, colSizeMb, token, hostname, status){
+        if (!this.canHandle(imagesCount, colSizeMb)) throw new Error(`Cannot handle ${imagesCount} images.`);
 
         const dm = new DockerMachine(hostname);
         const args = ["--driver", this.getDriverName()]
-                        .concat(await this.getCreateArgs(imagesCount));
+                        .concat(await this.getCreateArgs(imagesCount, colSizeMb));
         const nodeToken = short.generate();
 
         try{


### PR DESCRIPTION
Allows for an additional optional autoscaling configuration parameter 'maxColSizeMb', which defines the total size of the collection to be processed. This was identified as a useful parameter particularly for high resolution imagery, given that the size of individual images can be as large as 20 or 30 MB per file and subsequently take up a lot more memory on the processing node.