### PR TITLE
allow option to only assign AWS private address to prevent public ip charges

### DIFF
--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -34,6 +34,7 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 	    "vpc": "",
 	    "subnet": "",
 	    "usePrivateAddress": false,
+	    "assignPrivateAddressOnly": false,
             "securityGroup": "CHANGEME!",
             "maxRuntime": -1,
             "maxUploadTime": -1,
@@ -190,6 +191,9 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
         if (this.getConfig("usePrivateAddress")) {
             args.push("--amazonec2-use-private-address");
+	    if(this.getConfig("assignPrivateAddressOnly")) {
+	        args.push("--amazonec2-private-address-only");
+	    }
         }
 
         if (this.getConfig("engineInstallUrl")){


### PR DESCRIPTION
The current --amazonec2-use-private-address option does not mean that docker-machine will not assign the machine a public IP address even if the VM is deployed into a private subnet. Adding a config option to also prevent a public IP from being assigned at all will improve security and prevent public IP address charges from AWS.