### PR TITLE
Emulate socket drop

### DIFF
--- a/libs/proxy.js
+++ b/libs/proxy.js
@@ -162,7 +162,15 @@ module.exports = {
 
         // Listen for the `error` event on `proxy`.
         proxy.on('error', function (err, req, res) {
-            json(res, {error: `Proxy redirect error: ${err.message}`});
+            // If the error is caused by a connection issue,
+            // we actually simulate the same behavior by dropping the connection
+            // because returning an error could make a NodeODM client assume that something failed
+            if (res.socket && (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED')){
+                logger.warn(`Proxy redirect error: ${err.message}`);
+                res.socket.destroy();
+            }else{
+                json(res, {error: `Proxy redirect error: ${err.message}`});
+            }
         });
 
         // Added for CORS support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When we get a connection error, we should actually "emulate" the connection error rather than sending an error back, because NodeODM clients might think that some error (rather than a fluke) happened. 

Perhaps in the future we could expand the NodeODM API to differentiate between unrecoverable errors and errors that should be retried, but I have a feel it would complicate things.