### PR TITLE
Upgrade base image and package compatibility to node v16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:14
-MAINTAINER Piero Toffanin <pt@masseranolabs.com>
-
-EXPOSE 3000
-
+ARG NODE_IMG_TAG=14
+FROM node:${NODE_IMG_TAG} AS base
+ARG NODE_IMG_TAG
+LABEL opendronemap.org.app-name="clusterodm" \
+      opendronemap.org.node-img-tag="${NODE_IMG_TAG}" \
+      opendronemap.org.maintainer="Piero Toffanin <pt@masseranolabs.com>" \
+      opendronemap.org.api-port="3000"
+WORKDIR "/var/www"
 USER root
 
-RUN apt update && apt install -y telnet curl && \
-    base=https://gitlab-docker-machine-downloads.s3.amazonaws.com/main && \
+
+FROM base AS docker-machine
+RUN base=https://gitlab-docker-machine-downloads.s3.amazonaws.com/main && \
     curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine && \
     install /tmp/docker-machine /usr/local/bin/docker-machine && \
     curl -L https://github.com/scaleway/docker-machine-driver-scaleway/releases/download/v1.6/docker-machine-driver-scaleway_1.6_linux_amd64.tar.gz | tar -xz --directory=/tmp && \
@@ -14,15 +18,29 @@ RUN apt update && apt install -y telnet curl && \
     curl -L https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/2.0.1/docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz | tar -xz --directory=/tmp && \
     install --mode +x /tmp/docker-machine-driver-hetzner /usr/local/bin/
 
-RUN mkdir /var/www
-WORKDIR "/var/www"
+
+FROM base AS build
+COPY package.json /var/www/
+RUN npm install --production
+
+
+FROM node:${NODE_IMG_TAG} AS runtime
+RUN apt-get update --quiet \
+    && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --quiet --no-install-recommends \
+        "telnet" \
+        "curl" \
+        "dnsutils" \
+    && rm -rf /var/lib/apt/lists/*
+COPY --chown=node:node --from=build /var/www/node_modules /var/www/node_modules
+COPY --chown=node:node --from=docker-machine /usr/local/bin /usr/local/bin
 COPY --chown=node:node . /var/www
-
-RUN npm install
-
 RUN chown -R node:node /var/www
 
-USER node
 
+FROM scratch
+COPY --from=runtime / /
+WORKDIR "/var/www"
+USER node
 VOLUME ["/var/www/data"]
 ENTRYPOINT ["/usr/local/bin/node", "/var/www/index.js"]

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -17,7 +17,7 @@
  */
 "use strict";
 
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
 const async = require('async');
 const logger = require('./logger');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.5.5",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -15,20 +15,20 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "async": "^2.6.1",
-    "aws-sdk": "^2.466.0",
-    "axios": "^0.18.0",
-    "busboy": "^0.2.14",
+    "aws-sdk": "^2.1692.0",
+    "axios": "^0.27.2",
+    "busboy": "^0.3.1",
     "cors": "^2.8.5",
-    "express": "^4.16.4",
-    "express-basic-auth": "^1.2.0",
-    "http-proxy": "^1.17.0",
-    "minimist": "^1.2.0",
-    "node-libcurl": "^2.0.3",
+    "express": "^4.21.2",
+    "express-basic-auth": "^1.2.1",
+    "http-proxy": "^1.18.1",
+    "minimist": "^1.2.8",
+    "node-libcurl": "^2.3.4",
     "rimraf": "^2.6.2",
     "short-uuid": "^3.1.1",
-    "tree-kill": "^1.2.1",
-    "uuid": "^3.3.2",
-    "winston": "^3.3.3"
+    "tree-kill": "^1.2.2",
+    "uuid": "^11.1.0",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "archiver": "^3.0.0"


### PR DESCRIPTION
Fixes #116

- Swapped to a `-slim` node image. Had to add ca-certificates package manually after so curl commands work.
- Minor deprecation of `uuid/v4` usage --> updated syntax.
- Updated most packages with MINOR semver.
  - Bumped `uuid` package to latest MAJOR, as no breaking changes or node version pin requirements specified.
  - `aws-sdk` is also the latest version, as no MAJOR bump required.
  - `express` v4 seems to be still maintained in parallel to v5, with the latest PATCH about 4 months ago.
  - `winston` was also updated to latest without issue.
- Bumped ClusterODM version --> 2.0.0.

The application starts and simple GET endpoints work. I haven't tested actual processing, but as this is just as a relay to NodeODM, I'm assuming there probably shouldn't be issues 🤞 