### PR TITLE
Adds ability to rotate regions on failure

### DIFF
--- a/docs/digitalocean.md
+++ b/docs/digitalocean.md
@@ -18,7 +18,7 @@ Example configuration file:
     "maxRuntime": -1,
     "maxUploadTime": -1,
     "dropletsLimit": 30,
-    "region": "sfo2",
+    "region": ["sfo2", "sfo1"],
     
     "image": "ubuntu-16-04-x64",
     "tags": ["clusterodm"],

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -206,9 +206,9 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
         if (this.getConfig("usePrivateAddress")) {
             args.push("--amazonec2-use-private-address");
-        if(this.getConfig("assignPrivateAddressOnly")) {
-            args.push("--amazonec2-private-address-only");
-        }
+            if(this.getConfig("assignPrivateAddressOnly")) {
+                args.push("--amazonec2-private-address-only");
+            }
         }
 
         if (this.getConfig("engineInstallUrl")){

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -128,30 +128,29 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
         const webhook = netutils.publicAddressPath("/commit", req, token);
         
         const setupCmd = this.getConfig("nodeSetupCmd");
-        if (setupCmd != null && setupCmd.length > 0)
-        {
+        if (setupCmd != null && setupCmd.length > 0){
           await dm.ssh(setupCmd);
         }
 
         let dockerRunArgs = [`sudo docker run -d -p 3000:3000`];
 
-    if(dataDirMountPath.length > 0){
-        dockerRunArgs.push(`--mount type=bind,source=${dataDirMountPath},target=/var/www/data`);
-    }
-    if (this.getConfig("dockerGpu")){
-        dockerRunArgs.push(`--gpus all`);
-    }
-        
-    dockerRunArgs.push(`${dockerImage} -q 1`);
-    dockerRunArgs.push(`--s3_access_key ${accessKey}`);
-    dockerRunArgs.push(`--s3_secret_key ${secretKey}`);
-    dockerRunArgs.push(`--s3_endpoint ${s3.endpoint}`);
-    dockerRunArgs.push(`--s3_bucket ${s3.bucket}`);
-    dockerRunArgs.push(`--s3_acl ${s3.acl}`);
-    dockerRunArgs.push(`--webhook ${webhook}`);
-    dockerRunArgs.push(`--token ${nodeToken}`);
-        
-    await dm.ssh(dockerRunArgs.join(" "));
+        if(dataDirMountPath.length > 0){
+            dockerRunArgs.push(`--mount type=bind,source=${dataDirMountPath},target=/var/www/data`);
+        }
+        if (this.getConfig("dockerGpu")){
+            dockerRunArgs.push(`--gpus all`);
+        }
+            
+        dockerRunArgs.push(`${dockerImage} -q 1`);
+        dockerRunArgs.push(`--s3_access_key ${accessKey}`);
+        dockerRunArgs.push(`--s3_secret_key ${secretKey}`);
+        dockerRunArgs.push(`--s3_endpoint ${s3.endpoint}`);
+        dockerRunArgs.push(`--s3_bucket ${s3.bucket}`);
+        dockerRunArgs.push(`--s3_acl ${s3.acl}`);
+        dockerRunArgs.push(`--webhook ${webhook}`);
+        dockerRunArgs.push(`--token ${nodeToken}`);
+            
+        await dm.ssh(dockerRunArgs.join(" "));
     }
 
     getImagePropertiesFor(imagesCount){

--- a/libs/asr-providers/aws.js
+++ b/libs/asr-providers/aws.js
@@ -41,7 +41,7 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             "instanceLimit": -1,
             "createRetries": 1,
             "region": "us-west-2",
-	        "zone": "",
+            "zone": "",
             "monitoring": false,
             "tags": ["clusterodm"],
             "ami": "ami-07b4f3c02c7f83d59",
@@ -123,7 +123,7 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
         const dockerImage = this.getConfig("dockerImage");
         const accessKey = this.getConfig("accessKey");
         const secretKey = this.getConfig("secretKey");
-    	const dataDirMountPath = this.getConfig("dataDirMountPath");
+        const dataDirMountPath = this.getConfig("dataDirMountPath");
         const s3 = this.getConfig("s3");
         const webhook = netutils.publicAddressPath("/commit", req, token);
         
@@ -135,22 +135,22 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
         let dockerRunArgs = [`sudo docker run -d -p 3000:3000`];
 
-	if(dataDirMountPath.length > 0){
-	    dockerRunArgs.push(`--mount type=bind,source=${dataDirMountPath},target=/var/www/data`);
-	}
+    if(dataDirMountPath.length > 0){
+        dockerRunArgs.push(`--mount type=bind,source=${dataDirMountPath},target=/var/www/data`);
+    }
     if (this.getConfig("dockerGpu")){
         dockerRunArgs.push(`--gpus all`);
     }
-	    
-	dockerRunArgs.push(`${dockerImage} -q 1`);
-	dockerRunArgs.push(`--s3_access_key ${accessKey}`);
-	dockerRunArgs.push(`--s3_secret_key ${secretKey}`);
-	dockerRunArgs.push(`--s3_endpoint ${s3.endpoint}`);
-	dockerRunArgs.push(`--s3_bucket ${s3.bucket}`);
-	dockerRunArgs.push(`--s3_acl ${s3.acl}`);
-	dockerRunArgs.push(`--webhook ${webhook}`);
-	dockerRunArgs.push(`--token ${nodeToken}`);
-	    
+        
+    dockerRunArgs.push(`${dockerImage} -q 1`);
+    dockerRunArgs.push(`--s3_access_key ${accessKey}`);
+    dockerRunArgs.push(`--s3_secret_key ${secretKey}`);
+    dockerRunArgs.push(`--s3_endpoint ${s3.endpoint}`);
+    dockerRunArgs.push(`--s3_bucket ${s3.bucket}`);
+    dockerRunArgs.push(`--s3_acl ${s3.acl}`);
+    dockerRunArgs.push(`--webhook ${webhook}`);
+    dockerRunArgs.push(`--token ${nodeToken}`);
+        
     await dm.ssh(dockerRunArgs.join(" "));
     }
 
@@ -177,12 +177,12 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, attempt){
         const image_props = this.getImagePropertiesFor(imagesCount);
         const args = [
             "--amazonec2-access-key", this.getConfig("accessKey"),
             "--amazonec2-secret-key", this.getConfig("secretKey"),
-            "--amazonec2-region", this.getConfig("region"),
+            "--amazonec2-region", this.getConfigArrayItem("region", attempt - 1),
             "--amazonec2-ami", this.getConfig("ami"),
             "--amazonec2-instance-type", image_props["slug"],
             "--amazonec2-root-size", image_props["storage"],
@@ -206,9 +206,9 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
 
         if (this.getConfig("usePrivateAddress")) {
             args.push("--amazonec2-use-private-address");
-	    if(this.getConfig("assignPrivateAddressOnly")) {
-	        args.push("--amazonec2-private-address-only");
-	    }
+        if(this.getConfig("assignPrivateAddressOnly")) {
+            args.push("--amazonec2-private-address-only");
+        }
         }
 
         if (this.getConfig("engineInstallUrl")){
@@ -216,27 +216,32 @@ module.exports = class AWSAsrProvider extends AbstractASRProvider{
             args.push(this.getConfig("engineInstallUrl"));
         }
 
-	if (this.getConfig("zone").length > 0){
-	    args.push("--amazonec2-zone")
-	    args.push(this.getConfig("zone"));
-	}
+        if (this.getConfig("zone").length > 0){
+            args.push("--amazonec2-zone")
+            args.push(this.getConfig("zone"));
+        }
 
         if (this.getConfig("vpc").length > 0){
             args.push("--amazonec2-vpc-id")
             args.push(this.getConfig("vpc"));
         }
 
-	if (this.getConfig("subnet").length > 0){
+        if (this.getConfig("subnet").length > 0){
             args.push("--amazonec2-subnet-id")
             args.push(this.getConfig("subnet"));
         }
 
-
-	if (this.getConfig("iamrole").length > 0){
+        if (this.getConfig("iamrole").length > 0){
             args.push("--amazonec2-iam-instance-profile")
             args.push(this.getConfig("iamrole"));
         }
 
         return args;
+    }
+
+    getFailureSleepTime(attempt){
+        const numRegions = this.getConfigArray("region").length;
+        if (attempt <= numRegions) return 1000;
+        else return 10000 * (attempt - numRegions);
     }
 };

--- a/libs/asr-providers/digitalocean.js
+++ b/libs/asr-providers/digitalocean.js
@@ -165,9 +165,9 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getImageInfo(){
+    async getImageInfo(attempt){
         let imageName = this.getConfig("image");
-        let imageRegion = this.getConfig("region");
+        let imageRegion = this.getConfigArrayItem("region", attempt - 1);
 
         if (this.getConfig("snapshot")){
             // We need to fetch the imageID
@@ -209,8 +209,8 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
         };
     }
 
-    async getCreateArgs(imagesCount){
-        const imageInfo = await this.getImageInfo();
+    async getCreateArgs(imagesCount, attempt){
+        const imageInfo = await this.getImageInfo(attempt);
 
         const args = [
             "--digitalocean-access-token", this.getConfig("accessToken"),
@@ -244,5 +244,11 @@ module.exports = class DigitalOceanAsrProvider extends AbstractASRProvider{
         }
 
         return args;
+    }
+
+    getFailureSleepTime(attempt){
+        const numRegions = this.getConfigArray("region").length;
+        if (attempt <= numRegions) return 1000;
+        else return 10000 * (attempt - numRegions);
     }
 };

--- a/libs/asr-providers/hetzner.js
+++ b/libs/asr-providers/hetzner.js
@@ -217,10 +217,11 @@ module.exports = class HetznerAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, attempt){
+
         const args = [
             "--hetzner-api-token", this.getConfig("apiToken"),
-            "--hetzner-server-location", this.getConfig("location"),
+            "--hetzner-server-location", this.getConfigArrayItem("location", attempt - 1),
             "--hetzner-server-type", this.getImageSlugFor(imagesCount)
         ];
 
@@ -249,5 +250,11 @@ module.exports = class HetznerAsrProvider extends AbstractASRProvider{
         }
 
         return args;
+    }
+
+    getFailureSleepTime(attempt){
+        const numLocs = this.getConfigArray("location").length;
+        if (attempt <= numLocs) return 1000;
+        else return 10000 * (attempt - numLocs);
     }
 };

--- a/libs/asr-providers/scaleway.js
+++ b/libs/asr-providers/scaleway.js
@@ -149,11 +149,11 @@ module.exports = class ScalewayAsrProvider extends AbstractASRProvider{
         return this.getConfig("maxUploadTime");
     }
 
-    async getCreateArgs(imagesCount){
+    async getCreateArgs(imagesCount, attempt){
         const args = [
             "--scaleway-organization", this.getConfig("organization"),
             "--scaleway-token", this.getConfig("secretToken"),
-            "--scaleway-region", this.getConfig("region"),
+            "--scaleway-region", this.getConfigArrayItem("region", attempt - 1),
             "--scaleway-image", this.getConfig("image"),
             "--scaleway-commercial-type", this.getImageSlugFor(imagesCount)
         ];
@@ -164,5 +164,11 @@ module.exports = class ScalewayAsrProvider extends AbstractASRProvider{
         }
 
         return args;
+    }
+
+    getFailureSleepTime(attempt){
+        const numRegions = this.getConfigArray("region").length;
+        if (attempt <= numRegions) return 1000;
+        else return 10000 * (attempt - numRegions);
     }
 };

--- a/libs/classes/AbstractASRProvider.js
+++ b/libs/classes/AbstractASRProvider.js
@@ -210,7 +210,7 @@ module.exports = class AbstractASRProvider{
     }
 
     getConfigArrayItem(key, idx){
-        let arr = this.getConfigArray(key, [""]);
+        let arr = this.getConfigArray(key, ["invalid"]);
         return arr[idx % arr.length];
     }
 }


### PR DESCRIPTION
This allows ASR providers to define regions/locations as an array (e.g. `"region": ["sfo2", "sfo1"],`) rather than a single string, each region will be tried in order before giving up the autoscaling. This is useful because sometimes a region has an outage or becomes unavailable. This makes the ASR more robust to failures.