### PR TITLE
Transient slots

### DIFF
--- a/libs/classes/Node.js
+++ b/libs/classes/Node.js
@@ -28,6 +28,7 @@ module.exports = class Node{
             info: {}
         };
         this.turn = 0;
+        this.transients = 0;
 
         this.timeout = 10000;
     }
@@ -161,7 +162,15 @@ module.exports = class Node{
     }
 
     availableSlots(){
-        return Math.max(0, this.getInfoProperty('maxParallelTasks', 0) - this.getInfoProperty('taskQueueCount', 0));
+        return Math.max(0, this.getInfoProperty('maxParallelTasks', 0) - this.getInfoProperty('taskQueueCount', 0) - this.transients);
+    }
+
+    incTransients(){
+        this.transients++;
+    }
+
+    decTransients(){
+        if (--this.transients < 0) this.transients = 0;
     }
 
     proxyTargetUrl(){

--- a/libs/nodes.js
+++ b/libs/nodes.js
@@ -151,7 +151,7 @@ module.exports = {
             return {
                 node: n,
                 maxImages: n.getInfo().maxImages ? n.getInfo().maxImages : 999999999,
-                slots: Math.max(0, n.getInfo().maxParallelTasks - n.getInfo().taskQueueCount),
+                slots: n.availableSlots(),
                 queueCount: n.getInfo().taskQueueCount
             };
         });

--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -307,7 +307,7 @@ module.exports = {
         if (!approved) throw new Error(error);
 
         let node = await nodes.findBestAvailableNode(imagesCount, true);
-
+        
         // Do we need to / can we create a new node via autoscaling?
         const autoscale = (!node || node.availableSlots() === 0) && 
                             asrProvider.isAllowedToCreateNewNodes() &&
@@ -524,10 +524,14 @@ module.exports = {
                 eventEmitter.emit('close');
 
                 try{
+                    if (!autoscale) node.incTransients();
                     await taskNewInit();
                     await taskNewUpload();
                     await taskNewCommit();
+                    if (!autoscale) node.decTransients();
                 }catch(e){
+                    if (!autoscale) node.decTransients();
+
                     // Attempt to retry
                     if (retries < MAX_UPLOAD_RETRIES){
                         retries++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClusterODM",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Improves the best node selection by adding the concept of transient tasks (tasks that are in transit to a node, but haven't appeared in the node's queue), because sometimes when multiple tasks are sent in quick succession these tasks might get sent to the same node and when they arrive, some of them will get queued. It's better to preempt this by knowing that the nodes WILL receive a task and that subsequent selections for the best node should pick a different node, or autoscale. 